### PR TITLE
Enable semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 sudo: false
 language: node_js
+cache:
+  directories:
+    - node_modules
 notifications:
   email: false
 node_js:
-  - 4
+  - '4'
+before_install:
+  - npm i -g npm@^2.0.0
 before_script:
   - npm prune
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - "/^v\\d+\\.\\d+\\.\\d+$/"
 env:
   matrix:
     - CLIENT=saucelabs:chrome
-script: npm run test

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@hoodie/store",
-  "version": "0.0.0-semantically-released",
   "description": "Hoodie's Store API",
   "main": "server/index.js",
   "browser": "client/index.js",
   "scripts": {
     "pretest": "standard",
     "test": "frontend-test-background mocha test/*.js",
-    "start": "node example/"
+    "start": "node example/",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hoodiehq/hoodie-store.git"
+    "url": "https://github.com/hoodiehq/hoodie-store.git"
   },
   "keywords": [
     "hoodie",
@@ -41,7 +41,8 @@
     "mocha": "^2.4.5",
     "pouchdb": "^5.3.0",
     "random-string": "^0.1.2",
-    "standard": "^6.0.8"
+    "standard": "^6.0.8",
+    "semantic-release": "^6.2.1"
   },
   "frontend-test-setup": {
     "server": {


### PR DESCRIPTION
This should enable `semantic-release`  and publish `@hoodie/store` on npm. Closes #2
