### PR TITLE
Use modules from @hoodie org

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,1 +1,1 @@
-module.exports = require('hoodie-client-store')
+module.exports = require('@hoodie/store-client')

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/hoodiehq/hoodie-store#readme",
   "dependencies": {
-    "hoodie-client-store": "^4.1.0",
-    "hoodie-server-store": "^1.1.0"
+    "@hoodie/store-client": "^5.0.0",
+    "@hoodie/store-server": "^2.0.0"
   },
   "devDependencies": {
     "@gr2m/frontend-test-setup": "^1.2.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,1 +1,1 @@
-module.exports = require('hoodie-server-store')
+module.exports = require('@hoodie/store-server')


### PR DESCRIPTION
This PR changes the dependencies to the [new architecture](https://github.com/hoodiehq/hoodie/issues/458). 

I think this should not include any breaking changes (nor features), since the increasing major versions in the dependencies were only due to the renaming.

/cc @gr2m 
